### PR TITLE
Update the x chain deploy script for full TACO test

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -85,6 +85,8 @@ deployments:
         max_dkg_size: 8
         pre_application: '0x685b8Fd02aB87d8FfFff7346cB101A5cE4185bf3'
         verify: True
+        reward_duration: 604800  # one week in seconds
+        deauthorization_duration: 5184000  # 60 days in seconds
       - contract_type: fx_root
         address: '0x3d1d3E34f7fB6D26245E6640E1c50710eFFf15bA'
       - contract_type: checkpoint_manager


### PR DESCRIPTION
To run this script: `ape run deploy_xchain_test --network_type testnet --account ACCOUNT_NAME`

`ACCOUNT_NAME` needs both goerli and mumbai matic